### PR TITLE
N+1 문제 해결

### DIFF
--- a/src/main/java/com/woojkk/car/controller/BasicController.java
+++ b/src/main/java/com/woojkk/car/controller/BasicController.java
@@ -35,7 +35,8 @@ public class BasicController {
   }
 
   @PostMapping("/saveCompany")
-  public String saveCompany(@ModelAttribute(name = "companyInputDto")CompanyInputDto companyInputDto) {
+  public String saveCompany(
+      @ModelAttribute(name = "companyInputDto") CompanyInputDto companyInputDto) {
     companyService.saveCompanyInputDto(companyInputDto);
 
     return "index";
@@ -70,5 +71,13 @@ public class BasicController {
     model.addAttribute("carList", carList);
 
     return "carList";
+  }
+
+  @GetMapping("/carListNoPage")
+  public String carListNoPage(Model model) {
+    List<Car> carList = carService.getCarList();
+    model.addAttribute("carList", carList);
+
+    return "carListNoPage";
   }
 }

--- a/src/main/java/com/woojkk/car/domain/Car.java
+++ b/src/main/java/com/woojkk/car/domain/Car.java
@@ -6,6 +6,7 @@ import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -39,7 +40,7 @@ public class Car extends BaseEntity{
   @AttributeOverride(name = "value", column = @Column(name = "model_name"))
   private ModelName modelName;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "company_id")
   private Company company;
 

--- a/src/main/java/com/woojkk/car/repository/CarRepository.java
+++ b/src/main/java/com/woojkk/car/repository/CarRepository.java
@@ -3,6 +3,6 @@ package com.woojkk.car.repository;
 import com.woojkk.car.domain.Car;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CarRepository extends JpaRepository<Car, Long> {
+public interface CarRepository extends JpaRepository<Car, Long>, CarRepositoryCustom {
 
 }

--- a/src/main/java/com/woojkk/car/repository/CarRepositoryCustom.java
+++ b/src/main/java/com/woojkk/car/repository/CarRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.woojkk.car.repository;
+
+import com.woojkk.car.domain.Car;
+import java.util.List;
+
+public interface CarRepositoryCustom {
+  List<Car> getCarListByFetchJoin();
+}

--- a/src/main/java/com/woojkk/car/repository/CarRepositoryCustomImpl.java
+++ b/src/main/java/com/woojkk/car/repository/CarRepositoryCustomImpl.java
@@ -1,0 +1,20 @@
+package com.woojkk.car.repository;
+
+import com.woojkk.car.domain.Car;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CarRepositoryCustomImpl implements CarRepositoryCustom {
+  @PersistenceContext
+  EntityManager em;
+
+  @Override
+  public List<Car> getCarListByFetchJoin() {
+    String query = "select car from Car car join fetch car.company ";
+
+    return em.createQuery(query, Car.class).getResultList();
+  }
+}

--- a/src/main/java/com/woojkk/car/service/CarService.java
+++ b/src/main/java/com/woojkk/car/service/CarService.java
@@ -40,4 +40,9 @@ public class CarService {
   public void saveAll(List<Car> companyList) {
     carRepository.saveAll(companyList);
   }
+
+  public List<Car> getCarList() {
+    return carRepository.getCarListByFetchJoin();
+
+  }
 }

--- a/src/main/resources/templates/carListNoPage.html
+++ b/src/main/resources/templates/carListNoPage.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="">
+  <meta charset="UTF-8">
+  <title>Car</title>
+</head>
+<body>
+<h1>Car LIST</h1>
+<table border="1">
+  <tr>
+    <th>idx</th>
+    <th>model name</th>
+    <th>passengerCapacity</th>
+    <th>company nation</th>
+  </tr>
+  <tr th:each="car : ${carList}">
+    <td th:text="${car.id}"></td>
+    <td th:text="${car.modelName.value}"></td>
+    <td th:text="${car.passengerCapacity.value}"></td>
+    <td th:text="${car.company.companyName.value}"></td>
+    <td th:text="${car.company.companyNation.value}"></td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
N+1 문제의 이해를 위해 fetch join를 사용 해보았습니다.
(ManyToOne의 default인 eager로 두면 문제는 발생하지 않지만 문제 상황을 만들어 해결해보았습니다.)

fetchType을 lazy로 하고
getCarPage를 통해 findAll()사용하면
각 차량에 대한 회사 정보를 가져오기 위해 + N 만큼의 쿼리가 추가 실행됩니다. ("/carList" 페이지)

![스크린샷(201)](https://github.com/woojkk/car/assets/122269418/b3ffcab2-b628-4a19-ba05-bd8e3568ac7d)

이를 해결하기 위해

getCarList를 통해 커스텀으로 getCarList를 만들어
fetch join를 사용하여 Car와 Company 엔티티를 한번의 쿼리로 가져오도록 구현하였습니다. ("/carListNoPage" 페이지)

![스크린샷(202)](https://github.com/woojkk/car/assets/122269418/c5752e3a-98aa-45d8-b1ee-184b0c39dde9)